### PR TITLE
CS: Require Interface, not implementation. Eliminate testing var

### DIFF
--- a/src/MusicBrainz/MusicBrainz.php
+++ b/src/MusicBrainz/MusicBrainz.php
@@ -2,7 +2,7 @@
 
 namespace MusicBrainz;
 
-use Guzzle\Http\Client;
+use Guzzle\Http\ClientInterface;
 
 /**
  * Connect to the MusicBrainz web service
@@ -273,7 +273,7 @@ class MusicBrainz
     /**
      * The Guzzle client used to make cURL requests
      *
-     * @var \Guzzle\Http\Client
+     * @var \Guzzle\Http\ClientInterface
      */
     private $client;
 
@@ -281,11 +281,11 @@ class MusicBrainz
      * Initializes the class. You can pass the user’s username and password
      * However, you can modify or add all values later.
      *
-     * @param \Guzzle\Http\Client $client   The Guzzle client used to make requests
-     * @param string              $user
-     * @param string              $password
+     * @param \Guzzle\Http\ClientInterface $client   The Guzzle client used to make requests
+     * @param string                       $user
+     * @param string                       $password
      */
-    public function __construct(Client $client, $user = null, $password = null)
+    public function __construct(ClientInterface $client, $user = null, $password = null)
     {
         $this->client = $client;
 

--- a/tests/MusicBrainz/Tests/MusicBrainzTest.php
+++ b/tests/MusicBrainz/Tests/MusicBrainzTest.php
@@ -3,7 +3,6 @@
 namespace MusicBrainz\Tests;
 
 use MusicBrainz\MusicBrainz;
-use Guzzle\Http\Client;
 
 /**
  * @covers MusicBrainz\MusicBrainz
@@ -12,7 +11,7 @@ class MusicBrainzTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->brainz = new MusicBrainz(new Client());
+        $this->brainz = new MusicBrainz($this->getMock('\Guzzle\Http\ClientInterface'));
     }
 
     public function MBIDProvider()


### PR DESCRIPTION
If available, it's better to require interfaces rather than implementations.  It allows the end-user more flexibility.

While insignificant, the unit test change was more of a demonstration: you should eliminate as many variables as possible when unit testing to ensure you're isolating what you are testing.  Mocking an object you're not testing lets you control how it behaves in order to replicate expected results with what you are testing. 
