### PR TITLE
Fixed problem where arids are extraneously escaped

### DIFF
--- a/src/MusicBrainz/Filters/AbstractFilter.php
+++ b/src/MusicBrainz/Filters/AbstractFilter.php
@@ -35,7 +35,12 @@ abstract class AbstractFilter
                     if ($params['query'] != '') {
                         $params['query'] .= '+AND+';
                     }
-                    $params['query'] .= $key . ':' .  urlencode(preg_replace('/([\+\-\!\(\)\{\}\[\]\^\~\*\?\:\\\\])/', '/$1', $val));
+                    if ($key == 'arid')
+                    {
+                        $params['query'] .= $key . ':' . $val;
+                    } else {
+                        $params['query'] .= $key . ':' .  urlencode(preg_replace('/([\+\-\!\(\)\{\}\[\]\^\~\*\?\:\\\\])/', '/$1', $val));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This means you can now look up recordings with arid: without the API breaking!

Probably required for other filter parameters that take MBidz
