### PR TITLE
Fixed crash when the begin date of a artist life-span isn't set.

### DIFF
--- a/src/MusicBrainz/Artist.php
+++ b/src/MusicBrainz/Artist.php
@@ -30,7 +30,7 @@ class Artist
         $this->sortName  = isset($artist['sort-name']) ? (string) $artist['sort-name'] : '';
         $this->gender    = isset($artist['gender']) ? (string) $artist['gender'] : '';
         $this->country   = isset($artist['country']) ? (string) $artist['country'] : '';
-        $this->beginDate = isset($artist['life-span']) ? (string) $artist['life-span']['begin'] : '';
-        $this->endDate   = isset($artist['life-span']) ? (string) $artist['life-span']['ended'] : '';
+        $this->beginDate = isset($artist['life-span']['begin']) ? (string) $artist['life-span']['begin'] : '';
+        $this->endDate   = isset($artist['life-span']['ended']) ? (string) $artist['life-span']['ended'] : '';
     }
 }


### PR DESCRIPTION
This fixes a bug I had when looking up a artist without a begin, life-span date.
