### PR TITLE
Abstraction on HTTP clients and add Requests client support

### DIFF
--- a/examples/browse.php
+++ b/examples/browse.php
@@ -1,12 +1,13 @@
 <pre><?php
 
 use MusicBrainz\MusicBrainz;
+use MusicBrainz\Clients\GuzzleMbClient;
 use Guzzle\Http\Client;
 
 require_once '../vendor/autoload.php';
 
 //Create new phpBrainz object
-$brainz = new MusicBrainz(new Client());
+$brainz = new MusicBrainz(new GuzzleMbClient(new Client()));
 $brainz->setUserAgent('ApplicationName', '0.1', 'http://example.com');
 
 $includes = array('labels', 'recordings');

--- a/examples/lookup.php
+++ b/examples/lookup.php
@@ -1,12 +1,13 @@
 <pre><?php
 
 use MusicBrainz\MusicBrainz;
+use MusicBrainz\Clients\GuzzleMbClient;
 use Guzzle\Http\Client;
 
 require_once '../vendor/autoload.php';
 
 //Create new phpBrainz object
-$brainz = new MusicBrainz(new Client(), 'username', 'password');
+$brainz = new MusicBrainz(new GuzzleMbClient(new Client()), 'username', 'password');
 $brainz->setUserAgent('ApplicationName', '0.1', 'http://example.com');
 
 $includes = array(

--- a/examples/search.php
+++ b/examples/search.php
@@ -1,6 +1,7 @@
 <pre><?php
 
 use MusicBrainz\MusicBrainz;
+use MusicBrainz\Clients\GuzzleMbClient;
 use MusicBrainz\Filters\ArtistFilter;
 use MusicBrainz\Filters\RecordingFilter;
 use MusicBrainz\Filters\LabelFilter;
@@ -9,7 +10,7 @@ use Guzzle\Http\Client;
 require_once '../vendor/autoload.php';
 
 //Create new phpBrainz object
-$brainz = new MusicBrainz(new Client());
+$brainz = new MusicBrainz(new GuzzleMbClient(new Client()));
 $brainz->setUserAgent('ApplicationName', '0.1', 'http://example.com');
 
 $args = array(

--- a/src/MusicBrainz/Clients/GuzzleMbClient.php
+++ b/src/MusicBrainz/Clients/GuzzleMbClient.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MusicBrainz\Clients;
+
+use MusicBrainz\Exception;
+use Guzzle\Http\ClientInterface;
+
+/**
+ * Guzzle Client
+ */
+class GuzzleMbClient extends MbClient
+{
+    /**
+     * The Guzzle client used to make cURL requests
+     *
+     * @var \Guzzle\Http\ClientInterface
+     */
+    private $client;
+
+    /**
+     * Initializes the class.
+     *
+     * @param \Guzzle\Http\ClientInterface $client   The Guzzle client used to make requests
+     */
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Perform an HTTP request on MusicBrainz
+     *
+     * @param  string $path
+     * @param  array  $params
+     * @param  string $options
+     * @param  boolean $isAuthRequred
+     * @return array
+     */
+    public function call($path, array $params = array(), array $options = array(), $isAuthRequred = false)
+    {
+        if ($options['user-agent'] == '') {
+            throw new Exception('You must set a valid User Agent before accessing the MusicBrainz API');
+        }
+
+        $this->client->setBaseUrl(MbClient::URL);
+        $this->client->setConfig(array(
+            'data' => $params
+        ));
+
+        $request = $this->client->get($path . '{?data*}');
+        $request->setHeader('Accept', 'application/json');
+        $request->setHeader('User-Agent', $options['user-agent']);
+
+        if ($isAuthRequred) {
+            if ($options['user'] != null && $options['password'] != null) {
+                $request->setAuth($options['user'], $options['password'], CURLAUTH_DIGEST);
+            } else {
+                throw new Exception('Authentication is required');
+            }
+        }
+
+        $request->getQuery()->useUrlEncoding(false);
+
+        return $request->send()->json();
+    }
+}

--- a/src/MusicBrainz/Clients/MbClient.php
+++ b/src/MusicBrainz/Clients/MbClient.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MusicBrainz\Clients;
+
+/**
+ * MusicBrainz HTTP Client interfance
+ */
+abstract class MbClient
+{
+    const URL = 'http://musicbrainz.org/ws/2';
+    
+    /**
+     * Perform an HTTP request on MusicBrainz
+     *
+     * @param  string $path
+     * @param  array  $params
+     * @param  string $options
+     * @param  boolean $isAuthRequred
+     * @return array
+     */
+    abstract public function call($path, array $params = array(), array $options = array(), $isAuthRequred = false);
+}

--- a/src/MusicBrainz/Clients/RequestsMbClient.php
+++ b/src/MusicBrainz/Clients/RequestsMbClient.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MusicBrainz\Clients;
+
+use MusicBrainz\Exception;
+use Requests;
+
+/**
+ * Requests Client
+ */
+class RequestsMbClient extends MbClient
+{
+    /**
+     * Initializes the class.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Perform an HTTP request on MusicBrainz
+     *
+     * @param  string $path
+     * @param  array  $params
+     * @param  string $options
+     * @param  boolean $isAuthRequred
+     * @return array
+     */
+    public function call($path, array $params = array(), array $options = array(), $isAuthRequred = false)
+    {
+        if ($options['user-agent'] == '') {
+            throw new Exception('You must set a valid User Agent before accessing the MusicBrainz API');
+        }
+        
+        $url = MbClient::URL . '/' . $path;
+        $i = 0;
+        foreach ($params as $name => $value)
+        {
+            if ($i == 0) $url .= '?';
+            else $url .= '&';
+            
+            $url .= urlencode($name) . '=' . urlencode($value);
+            ++$i;
+        }
+        $headers = array();
+        $headers['Accept'] = 'application/json';
+        $headers['User-Agent'] = $options['user-agent'];
+        $reqopt = array();
+        if ($isAuthRequred) {
+            if ($options['user'] != null && $options['password'] != null) {
+                $reqopt['auth'] = array($options['user'], $options['password']);
+            } else {
+                throw new Exception('Authentication is required');
+            }
+        }
+        $request = Requests::get($url, $headers, $reqopt);
+
+        return json_decode($request->body);
+    }
+}

--- a/tests/MusicBrainz/Tests/MusicBrainzTest.php
+++ b/tests/MusicBrainz/Tests/MusicBrainzTest.php
@@ -3,6 +3,7 @@
 namespace MusicBrainz\Tests;
 
 use MusicBrainz\MusicBrainz;
+use MusicBrainz\Clients\GuzzleMbClient;
 
 /**
  * @covers MusicBrainz\MusicBrainz
@@ -11,7 +12,7 @@ class MusicBrainzTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->brainz = new MusicBrainz($this->getMock('\Guzzle\Http\ClientInterface'));
+        $this->brainz = new MusicBrainz(new GuzzleMbClient($this->getMock('\Guzzle\Http\ClientInterface')));
     }
 
     public function MBIDProvider()


### PR DESCRIPTION
My project cannot have strong dependency with cUrl and because of that I cannot use Guzzle.
I added an abstraction level for HTTP clients and also added Requests project support (http://requests.ryanmccue.info/) which uses cUrl or fsockopen according to what available.
Requests can also be used with Composer:  `"rmccue/requests": ">=1.0"`
