### PR TITLE
fixed escape character

### DIFF
--- a/src/MusicBrainz/Filters/AbstractFilter.php
+++ b/src/MusicBrainz/Filters/AbstractFilter.php
@@ -39,7 +39,7 @@ abstract class AbstractFilter
                     {
                         $params['query'] .= $key . ':' . $val;
                     } else {
-                        $params['query'] .= $key . ':' .  urlencode(preg_replace('/([\+\-\!\(\)\{\}\[\]\^\~\*\?\:\\\\])/', '/$1', $val));
+                        $params['query'] .= $key . ':' .  urlencode(preg_replace('/([\+\-\!\(\)\{\}\[\]\^\~\*\?\:\\\\])/', '\\\\$1', $val));
                     }
                 }
             }


### PR DESCRIPTION
trying this:
$brainz->search(new ReleaseFilter(array("release" => "-")));

getting this:
http://musicbrainz.org/ws/2/release/?limit=25&offset=&fmt=json&query=release:/- 400 Bad Request

should be:
http://musicbrainz.org/ws/2/release/?limit=25&offset=&fmt=json&query=release:\- 200 OK
