### PR TITLE
HttpAdapter can force json_decode to return an array

### DIFF
--- a/src/MusicBrainz/HttpAdapters/AbstractHttpAdapter.php
+++ b/src/MusicBrainz/HttpAdapters/AbstractHttpAdapter.php
@@ -19,8 +19,9 @@ abstract class AbstractHttpAdapter
      * @param  array   $params
      * @param  array   $options
      * @param  boolean $isAuthRequired
+     * @param  boolean $returnArray
      *
      * @return array
      */
-    abstract public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false);
+    abstract public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false, $returnArray = false);
 }

--- a/src/MusicBrainz/HttpAdapters/GuzzleHttpAdapter.php
+++ b/src/MusicBrainz/HttpAdapters/GuzzleHttpAdapter.php
@@ -39,11 +39,12 @@ class GuzzleHttpAdapter extends AbstractHttpAdapter
      * @param  array   $params
      * @param  array   $options
      * @param  boolean $isAuthRequired
+     * @param  boolean $returnArray disregarded
      *
      * @throws \MusicBrainz\Exception
      * @return array
      */
-    public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false)
+    public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false, $returnArray = false)
     {
         if ($options['user-agent'] == '') {
             throw new Exception('You must set a valid User Agent before accessing the MusicBrainz API');

--- a/src/MusicBrainz/HttpAdapters/RequestsHttpAdapter.php
+++ b/src/MusicBrainz/HttpAdapters/RequestsHttpAdapter.php
@@ -30,11 +30,12 @@ class RequestsHttpAdapter extends AbstractHttpAdapter
      * @param  array   $params
      * @param  array   $options
      * @param  boolean $isAuthRequired
+     * @param  boolean $returnArray force json_decode to return an array instead of an object
      *
      * @throws \MusicBrainz\Exception
      * @return array
      */
-    public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false)
+    public function call($path, array $params = array(), array $options = array(), $isAuthRequired = false, $returnArray = false)
     {
         if ($options['user-agent'] == '') {
             throw new Exception('You must set a valid User Agent before accessing the MusicBrainz API');
@@ -65,6 +66,6 @@ class RequestsHttpAdapter extends AbstractHttpAdapter
         // musicbrainz throttle
         sleep(1);
 
-        return json_decode($request->body);
+        return json_decode($request->body, $returnArray);
     }
 }

--- a/src/MusicBrainz/MusicBrainz.php
+++ b/src/MusicBrainz/MusicBrainz.php
@@ -542,7 +542,7 @@ class MusicBrainz
 
         $params = $filter->createParameters(array('limit' => $limit, 'offset' => $offset, 'fmt' => 'json'));
 
-        $response = $this->adapter->call($filter->getEntity() . '/', $params, $this->getHttpOptions());
+        $response = $this->adapter->call($filter->getEntity() . '/', $params, $this->getHttpOptions(), false, true);
 
         return $filter->parseResponse($response, $this);
     }


### PR DESCRIPTION
search() would throw an exception where json_decode returned an object to RequestHttpAdapter, as FilterInterface::parseResponse expects an array. I added a parameter to the call method so that search() can specify what it wants to be returned. Fixes issue #1006 in ampache, for example.