### PR TITLE
update guzzle client call to prevent overwriting existing config

### DIFF
--- a/src/MusicBrainz/HttpAdapters/GuzzleHttpAdapter.php
+++ b/src/MusicBrainz/HttpAdapters/GuzzleHttpAdapter.php
@@ -52,8 +52,11 @@ class GuzzleHttpAdapter extends AbstractHttpAdapter
 
         $this->client->setBaseUrl($this->endpoint);
         $this->client->setConfig(
-            array(
-                'data' => $params
+            array_merge(
+                $this->client->getConfig()->toArray(),
+                array(
+                    'data' => $params
+                )
             )
         );
 


### PR DESCRIPTION
When creating a Guzzle Client to pass to the GuzzleHttpAdapter, the config and default options of that client were being overridden in the GuzzleHttpAdapter::call method.

I have updated the way the 'data' is set for the request, so that it preserves any existing config.  