### PR TITLE
Add compatibility with guzzle 6.3.0

### DIFF
--- a/examples/guzzle-six.php
+++ b/examples/guzzle-six.php
@@ -1,0 +1,18 @@
+<?php
+
+use GuzzleHttp\Client;
+use MusicBrainz\MusicBrainz;
+use MusicBrainz\Filters\ArtistFilter;
+use MusicBrainz\HttpAdapters\GuzzleSixHttpAdapter;
+
+// Tested with guzzle 6.3.0
+$musicBrainz = new MusicBrainz(new GuzzleSixHttpAdapter(new Client()));
+$musicBrainz->setUserAgent('ApplicationName', '0.2', 'http://example.com');
+
+try {
+    $artist = $musicBrainz->search(new ArtistFilter([ "artist" => 'Weezer' ]));
+    print_r($artist);
+} catch (\Exception $e) {
+    print $e->getMessage();
+}
+print "\n\n";

--- a/src/MusicBrainz/HttpAdapters/GuzzleSixHttpAdapter.php
+++ b/src/MusicBrainz/HttpAdapters/GuzzleSixHttpAdapter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MusicBrainz\HttpAdapters;
+
+use GuzzleHttp\ClientInterface;
+use MusicBrainz\Exception;
+
+class GuzzleSixHttpAdapter extends AbstractHttpAdapter
+{
+    private $client;
+
+    public function __construct(ClientInterface $client, $endpoint = null)
+    {
+        $this->client = $client;
+
+        if (filter_var($endpoint, FILTER_VALIDATE_URL)) {
+            $this->endpoint = $endpoint;
+        }
+    }
+
+    public function call($path, array $params = [], array $options = [], $isAuthRequired = false, $returnArray = false)
+    {
+        if ($options['user-agent'] == '') {
+            throw new Exception('You must set a valid User Agent before accessing the MusicBrainz API');
+        }
+
+        $guzzleOptions = [
+            'base_uri' => "{$this->endpoint}/",
+            'headers' => [
+                'Accept' => 'application/json',
+                'User-Agent' => $options['user-agent'],
+            ],
+            'query' => $params,
+        ];
+
+        if ($isAuthRequired) {
+            if ($options['user'] != null && $options['password'] != null) {
+                $guzzleOptions['auth'] = [
+                    $options['user'],
+                    $options['password'],
+                    'digest'
+                ];
+            } else {
+                throw new Exception('Authentication is required');
+            }
+        }
+
+        $request = $this->client->request('GET', $path, $guzzleOptions);
+
+        // musicbrainz throttle
+        sleep(1);
+
+        return json_decode((string) $request->getBody(), $returnArray);
+    }
+}


### PR DESCRIPTION
I haven't modified the composer file, but as guzzle 6.3.0 requires PHP 5.5, this adapter will break without that version of PHP.

Besides that, I'm going to be using this library pretty extensively for the next couple of months, would you be open to a modernization of the code? I would try to create some PRs to move to PHP 7.x, write some tests, clean the methods a little, etc.